### PR TITLE
`body` of `Request` should be optional

### DIFF
--- a/src/Network/HTTP/Types/Exchange.purs
+++ b/src/Network/HTTP/Types/Exchange.purs
@@ -95,7 +95,7 @@ newtype Request = Request
 	, headers :: Headers
 	, cookies :: List Cookie
 	, auth    :: Maybe Auth -- ^ If Auth information is provided in both the request.uri and request.auth, the auth in request.auth is preferred.
-	, body    :: String
+	, body    :: Maybe String
 	, timeout :: Maybe Milliseconds
 	}
 
@@ -160,7 +160,7 @@ defRequest        ::
 	, headers :: Headers
 	, cookies :: List Cookie
 	, auth    :: Maybe Auth
-	, body    :: String
+	, body    :: Maybe String
 	, timeout :: Maybe Milliseconds
 	}
 defRequest =
@@ -169,7 +169,7 @@ defRequest =
 	, headers: mempty
 	, cookies: mempty
 	, auth   : Nothing
-	, body   : ""
+	, body   : Nothing
 	, timeout: Nothing
 	}
 
@@ -258,7 +258,7 @@ setAuth :: Auth -> Request -> Request
 setAuth auth (Request r) = Request r { auth = Just auth }
 
 setBody :: String -> Request -> Request
-setBody body (Request r) = Request r { body = body }
+setBody body (Request r) = Request r { body = Just body }
 
 setTimeout :: Milliseconds -> Request -> Request
 setTimeout timeout (Request r) = Request r { timeout = Just timeout }


### PR DESCRIPTION
to support `Request` objects of [the `Fetch` standard](https://fetch.spec.whatwg.org/#dom-request) as well. The `fetch` specification does not support `body` for requests [in some cases](https://fetch.spec.whatwg.org/#dom-request):
> If either init’s body member is present and is non-null or inputBody is non-null, and request’s method is `GET` or `HEAD`, then throw a TypeError.

(Quote of #36 https://fetch.spec.whatwg.org/#dom-request)

Ignoring this ^ will thrown errors such as `Request with GET/HEAD method cannot have body` , see ["GET/HEAD method cannot have body"](https://github.com/sectore/purescript-isomorphic-fetch/issues/1).